### PR TITLE
Allow codename as alternative label for device

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -40,6 +40,8 @@ def validate(description):
                 if len(spaced) < 2:
                     continue
                 label, value = spaced[0:2]
+                if label == "codename":
+                    label = "device"
                 if value:
                     if label in seen:
                         errors.append(


### PR DESCRIPTION
* Instead of requiring "/device" with the codename, we can also just use "/codename", which is more obvious
* Replace the "codename" label with the "device" one so we are compatible to existing issues and labels